### PR TITLE
Fixed manual feedrate related errors.

### DIFF
--- a/TinyG2/config_app.h
+++ b/TinyG2/config_app.h
@@ -21,6 +21,19 @@
 #ifndef CONFIG_APP_H_ONCE
 #define CONFIG_APP_H_ONCE
 
+/* 
+ * The following is to fix an issue where feedrate override was being defined in some users
+ * settings files but not others. This would otherwise cause an undefined compile error.
+ *
+ */
+
+#ifndef MANUAL_FEEDRATE_OVERRIDE_ENABLE
+#define MANUAL_FEEDRATE_OVERRIDE_ENABLE false
+#endif
+#ifndef MANUAL_FEEDRATE_OVERRIDE_PARAMETER
+#define MANUAL_FEEDRATE_OVERRIDE_PARAMETER 1.00
+#endif
+
 /***********************************************************************************
  **** APPLICATION_SPECIFIC DEFINITIONS AND SETTINGS ********************************
  ***********************************************************************************/


### PR DESCRIPTION
This fixes an issue where feedrate override enable and parameters was being defined in some users
 settings files but not others. This would otherwise cause an undefined compile error. 
A couple ifndef checks were added.
